### PR TITLE
Release 1.2.2

### DIFF
--- a/DreamsEnterpriseSDK.podspec
+++ b/DreamsEnterpriseSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name           = "DreamsEnterpriseSDK"
-  s.version        = "1.2.1"
+  s.version        = "1.2.2"
   s.summary        = "Dreams Enterprise iOS SDK"
 
   s.homepage       = "http://dreamstech.com"

--- a/Sources/DreamsNetworkInteraction.swift
+++ b/Sources/DreamsNetworkInteraction.swift
@@ -60,6 +60,7 @@ public final class DreamsNetworkInteraction: DreamsNetworkInteracting {
     }
     
     public func update(headers: [String : String]?) {
+        webService.set(headers: headers)
         send(event: .setAdditionalHeaders, with: headers)
     }
 

--- a/Sources/DreamsViewController.swift
+++ b/Sources/DreamsViewController.swift
@@ -151,7 +151,12 @@ public class DreamsViewController: UIViewController {
         
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.translatesAutoresizingMaskIntoConstraints = false
-    
+
+        // Handy for debugging:
+        // if #available(iOS 16.4, *) {
+        //     webView.isInspectable = true
+        // }
+
         return webView
     }()
 

--- a/Sources/WebServiceJS.swift
+++ b/Sources/WebServiceJS.swift
@@ -30,18 +30,28 @@ enum WebServiceJS: String {
                                         
                 const originalFetch = window.fetch;
                                         
-                window.fetch = function(input, init) {
-                    if (!init) {
-                        init = {};
+                window.fetch = function(resource, options) {
+                    if (!options) {
+                        options = {};
                     }
 
-                    if (!init.headers) {
-                        init.headers = {};
+                    if (!options.headers) {
+                        options.headers = {};
                     }
+
                     for (const header in window.additionalHeaders) {
-                        init.headers[header] = window.additionalHeaders[header];
+                        options.headers[header] = window.additionalHeaders[header];
                     }
-                    return originalFetch(input, init);
+
+                    if (resource instanceof Request) {
+                        options.headers = Object.assign(
+                            {},
+                            Object.fromEntries(resource.headers.entries()),
+                            options.headers
+                        );
+                    }
+
+                    return originalFetch(resource, options);
                 };
             })();
         """


### PR DESCRIPTION
## Bugfixes:

- Update the webService headers when updating headers (not only the JS headers). This fixes a bug where regular links (i.e. not using turbo) were requested with old headers.
- Do not override existing headers when the Fetch API is called with a Request object. This fixes a bug where Content-Type was lost, causing failures to read sent parameters.